### PR TITLE
In case DownloadId exceeds int32 size, deserialization crashes.

### DIFF
--- a/Apple.Receipt.Models/AppleAppReceipt.cs
+++ b/Apple.Receipt.Models/AppleAppReceipt.cs
@@ -54,7 +54,7 @@ namespace Apple.Receipt.Models
         public string BundleId { get; set; }
 
         [JsonProperty("download_id")]
-        public int? DownloadId { get; set; }
+        public long? DownloadId { get; set; }
 
         /// <summary>
         ///     The receipt for an in-app purchase.


### PR DESCRIPTION
In my case, `DownloadId` value is 85069551843788