### PR TITLE
Fix deserialization issue when latest_receipt_info is an object

### DIFF
--- a/Apple.Receipt.Verificator/Models/IAPVerification/IAPVerificationResponse.cs
+++ b/Apple.Receipt.Verificator/Models/IAPVerification/IAPVerificationResponse.cs
@@ -31,7 +31,7 @@ namespace Apple.Receipt.Verificator.Models.IAPVerification
 
         [JsonProperty("receipt")]
         public AppleAppReceipt? Receipt { get; set; }
-        
+
         /// <summary>
         /// An indicator that an error occurred during the request.
         /// A value of TRUE indicates a temporary issue; retry validation for this receipt at a later time.
@@ -40,7 +40,7 @@ namespace Apple.Receipt.Verificator.Models.IAPVerification
         /// </summary>
         [JsonProperty("is-retryable")]
         public bool? IsRetryable { get; set; }
-        
+
         // /// <summary>
         // /// The latest app receipt (decoded from <see cref="LatestReceiptEncoded"/> into <see cref="AppleAppReceipt"/>).
         // /// Only returned for receipts that contain auto-renewable subscriptions.
@@ -52,7 +52,7 @@ namespace Apple.Receipt.Verificator.Models.IAPVerification
         /// </summary>
         [JsonProperty("latest_receipt")]
         public string? LatestReceiptEncoded { get; set; }
-        
+
         /// <summary>
         /// An array that contains all in-app purchase transactions.
         /// List of <see cref="AppleInAppPurchaseReceipt"/>
@@ -60,8 +60,9 @@ namespace Apple.Receipt.Verificator.Models.IAPVerification
         /// Only returned for receipts that contain auto-renewable subscriptions.
         /// </summary>
         [JsonProperty("latest_receipt_info")]
+        [JsonConverter(typeof(ObjectOrArrayToArrayConverter<AppleInAppPurchaseReceipt>))]
         public ICollection<AppleInAppPurchaseReceipt>? LatestReceiptInfo { get; set; }
-        
+
         /// <summary>
         /// An array where each element contains the pending renewal information for each auto-renewable subscription identified by the product_id.
         /// List of <see cref="AppleInAppPurchaseReceipt"/>

--- a/Apple.Receipt.Verificator/Models/IAPVerification/ObjectOrArrayToArrayConverter.cs
+++ b/Apple.Receipt.Verificator/Models/IAPVerification/ObjectOrArrayToArrayConverter.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+using System.Collections.ObjectModel;
+
+namespace Apple.Receipt.Verificator.Models.IAPVerification
+{
+    internal class ObjectOrArrayToArrayConverter<T> : JsonConverter
+    {
+        public override bool CanConvert(Type objectType) => objectType == typeof(ICollection<T>);
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var token = JToken.Load(reader);
+
+            if (token.Type == JTokenType.Array)
+                return token.ToObject<Collection<T>>();
+
+            return new Collection<T> { token.ToObject<T>() };
+        }
+
+        public override bool CanWrite => false;
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) => throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
Hi @shoshins

First of all, wanna thanks for the efforts you put into making such a great library. As we're using your library to verify our Apple receipts, I found a deserialization issue with some Apple responses. There are some cases where the verification's JSON has a different shape than what this library expected and this leads to a failure in parsing the result.

Here is a sample Apple response that causes the library to behave incorrectly:

```json
{
   "receipt":{
      "original_purchase_date_pst":"2020-01-31 04:14:01 America/Los_Angeles",
      "quantity":"1",
      "unique_vendor_identifier":"***",
      "bvrs":"***",
      "expires_date_formatted":"2020-02-29 12:14:00 Etc/GMT",
      "is_in_intro_offer_period":"false",
      "purchase_date_ms":"1580472840802",
      "expires_date_formatted_pst":"2020-02-29 04:14:00 America/Los_Angeles",
      "is_trial_period":"false",
      "item_id":"***",
      "unique_identifier":"***",
      "original_transaction_id":"***",
      "subscription_group_identifier":"***",
      "app_item_id":"***",
      "transaction_id":"***",
      "web_order_line_item_id":"***",
      "version_external_identifier":"***",
      "purchase_date":"2020-01-31 12:14:00 Etc/GMT",
      "product_id":"***",
      "expires_date":"1582978440802",
      "original_purchase_date":"2020-01-31 12:14:01 Etc/GMT",
      "purchase_date_pst":"2020-01-31 04:14:00 America/Los_Angeles",
      "bid":"***",
      "original_purchase_date_ms":"1580472841559"
   },
   "auto_renew_product_id":"***",
   "auto_renew_status":0,
   "latest_receipt_info":{
      "original_purchase_date_pst":"2020-01-31 04:14:01 America/Los_Angeles",
      "quantity":"1",
      "unique_vendor_identifier":"***",
      "bvrs":"***",
      "expires_date_formatted":"2021-12-12 11:34:15 Etc/GMT",
      "is_in_intro_offer_period":"false",
      "purchase_date_ms":"1607772855000",
      "expires_date_formatted_pst":"2021-12-12 03:34:15 America/Los_Angeles",
      "is_trial_period":"false",
      "item_id":"***",
      "unique_identifier":"***",
      "original_transaction_id":"***",
      "subscription_group_identifier":"***",
      "app_item_id":"***",
      "transaction_id":"***",
      "in_app_ownership_type":"PURCHASED",
      "web_order_line_item_id":"***",
      "purchase_date":"2020-12-12 11:34:15 Etc/GMT",
      "product_id":"***",
      "expires_date":"1639308855000",
      "original_purchase_date":"2020-01-31 12:14:01 Etc/GMT",
      "purchase_date_pst":"2020-12-12 03:34:15 America/Los_Angeles",
      "bid":"***",
      "original_purchase_date_ms":"1580472841000"
   },
   "latest_receipt":"***",
   "status":0
}
```

And the stack-trace of the exception:

```
Newtonsoft.Json.JsonSerializationException: Cannot deserialize the current JSON object (e.g. {"name":"value"}) into type 'System.Collections.Generic.ICollection`1[Apple.Receipt.Models.AppleInAppPurchaseReceipt]' because the type requires a JSON array (e.g. [1,2,3]) to deserialize correctly.
To fix this error either change the JSON to a JSON array (e.g. [1,2,3]) or change the deserialized type so that it is a normal .NET type (e.g. not a primitive type like integer, not a collection type like an array or List<T>) that can be deserialized from a JSON object. JsonObjectAttribute can also be added to the type to force it to deserialize from a JSON object.
Path 'latest_receipt_info.original_purchase_date_pst', line 3, position 52.
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue(JsonProperty property, JsonConverter propertyConverter, JsonContainerContract containerContract, JsonProperty containerProperty, JsonReader reader, Object target)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonSerializer.Deserialize[T](JsonReader reader)
   at Refit.NewtonsoftJsonContentSerializer.DeserializeAsync[T](HttpContent content) in /_/Refit/NewtonsoftJsonContentSerializer.cs:line 54
   at Refit.RequestBuilderImplementation.DeserializeContentAsync[T](HttpResponseMessage resp, HttpContent content) in /_/Refit/RequestBuilderImplementation.cs:line 317
   at Refit.RequestBuilderImplementation.<>c__DisplayClass14_0`2.<<BuildCancellableTaskFuncForMethod>b__0>d.MoveNext() in /_/Refit/RequestBuilderImplementation.cs:line 283
--- End of stack trace from previous location where exception was thrown ---
   at Apple.Receipt.Verificator.Services.AppleReceiptVerificatorService.VerifyReceiptAsync(String receiptData, IRestService restService)
warn: Zebble.Billing.AppStoreConnector[0]
      Something went wrong in IAP receipt verification.
info: System.Net.Http.HttpClient.Apple.Receipt.Verificator.Services.AutoGeneratedIRestService, Apple.Receipt.Verificator, Version=1.0.1.0, Culture=neutral, PublicKeyToken=null.LogicalHandler[100]
      Start processing HTTP request POST https://buy.itunes.apple.com/verifyReceipt
info: System.Net.Http.HttpClient.Apple.Receipt.Verificator.Services.AutoGeneratedIRestService, Apple.Receipt.Verificator, Version=1.0.1.0, Culture=neutral, PublicKeyToken=null.ClientHandler[100]
      Sending HTTP request POST https://buy.itunes.apple.com/verifyReceipt
info: System.Net.Http.HttpClient.Apple.Receipt.Verificator.Services.AutoGeneratedIRestService, Apple.Receipt.Verificator, Version=1.0.1.0, Culture=neutral, PublicKeyToken=null.ClientHandler[101]
      Received HTTP response after 342.0996ms - OK
info: System.Net.Http.HttpClient.Apple.Receipt.Verificator.Services.AutoGeneratedIRestService, Apple.Receipt.Verificator, Version=1.0.1.0, Culture=neutral, PublicKeyToken=null.LogicalHandler[101]
      End processing HTTP request after 342.1491ms - OK
fail: Apple.Receipt.Verificator.Services.AppleReceiptVerificatorService[0]
      Something went wrong in IAP receipt verification
```

Can you please verify and roll out the nuget package asap as I need this fix?