### PR TITLE
Invalid cast in SingleOrArrayConverter.WriteJson

### DIFF
--- a/Apple.Receipt.Verificator/Models/IAPVerification/ObjectOrArrayToArrayConverter.cs
+++ b/Apple.Receipt.Verificator/Models/IAPVerification/ObjectOrArrayToArrayConverter.cs
@@ -26,7 +26,7 @@ namespace Apple.Receipt.Verificator.Models.IAPVerification
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            var list = (List<T>) value;
+            var list = (Collection<T>) value;
             if (list.Count == 1)
             {
                 value = list[0];


### PR DESCRIPTION
`ReadJson` uses `Collection` while `WriteJson` tried to cast object to `List`.