### PR TITLE
🚀 Updated to NET70 and other NuGet 📦 updates

### DIFF
--- a/.github/workflows/ci master.yml
+++ b/.github/workflows/ci master.yml
@@ -9,16 +9,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
+      DOTNET_CLI_TELEMETRY_OPTOUT: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # shallow clone disabled as recommended by SonarCLoud - https://github.com/marketplace/actions/sonarcloud-scan
           fetch-depth: 0
-      - name: Setup .Net Core 6
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '6.0.x'
+      - name: Setup .Net
+        uses: actions/setup-dotnet@v3
       - name: Restore with .Net Core
         run: dotnet restore
       - name: Build with .Net Core

--- a/.github/workflows/ci pull requests.yml
+++ b/.github/workflows/ci pull requests.yml
@@ -9,16 +9,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
+      DOTNET_CLI_TELEMETRY_OPTOUT: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # shallow clone disabled as recommended by SonarCLoud - https://github.com/marketplace/actions/sonarcloud-scan
           fetch-depth: 0
       - name: Setup .Net Core 6
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '6.0.x'
+        uses: actions/setup-dotnet@v3
       - name: Restore with .Net Core
         run: dotnet restore
       - name: Build with .Net Core

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,24 +8,24 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     env:
-      DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
+      DOTNET_CLI_TELEMETRY_OPTOUT: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Fetch all history for all tags and branches
         run: git fetch --prune --unshallow
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.9.6
+        uses: gittools/actions/gitversion/setup@v0.10.2
         with:
           versionSpec: '5.x'
       - name: Use GitVersion
         id: gitversion # step id used as reference for output values
-        uses: gittools/actions/gitversion/execute@v0.9.6
+        uses: gittools/actions/gitversion/execute@v0.10.2
       - run: |
           echo "NuGetVersionV2: ${{ steps.gitversion.outputs.nuGetVersionV2 }}"
           echo "NuGetPreReleaseTagV2 (not used): ${{ steps.gitversion.outputs.CommitsSinceVersionSourcePadded }}"
       - name: Pack with .Net Core
-        run: dotnet pack --configuration Release --output nuget-packages -p:PackageVersion=${{ steps.gitversion.outputs.nuGetVersionV2 }}
-      - uses: actions/upload-artifact@v2
+        run: dotnet pack --configuration Release --output nuget-packages -p:PackageVersion=${{ steps.gitversion.outputs.nuGetVersionV2 }} -p:ContinuousIntegrationBuild=true
+      - uses: actions/upload-artifact@v3
         with:
           name: Nuget-packages-${{ steps.gitversion.outputs.nuGetVersionV2 }}
           path: nuget-packages

--- a/Apple.Receipt.Example.ConsoleApp/Apple.Receipt.Example.ConsoleApp.csproj
+++ b/Apple.Receipt.Example.ConsoleApp/Apple.Receipt.Example.ConsoleApp.csproj
@@ -1,15 +1,18 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10</LangVersion>
+        <TargetFramework>net7.0</TargetFramework>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Apple.Receipt.Parser" Version="2.2.4" />
-      <PackageReference Include="Apple.Receipt.Verificator" Version="2.2.4" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Apple.Receipt.Parser\Apple.Receipt.Parser.csproj" />
+      <ProjectReference Include="..\Apple.Receipt.Verificator\Apple.Receipt.Verificator.csproj" />
     </ItemGroup>
 
 </Project>

--- a/Apple.Receipt.Example.Tests/Apple.Receipt.Example.Tests/Apple.Receipt.Example.Tests.csproj
+++ b/Apple.Receipt.Example.Tests/Apple.Receipt.Example.Tests/Apple.Receipt.Example.Tests.csproj
@@ -1,16 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
-
+        <TargetFramework>net7.0</TargetFramework>
         <IsPackable>false</IsPackable>
-
-        <LangVersion>10</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.9" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.5" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
           <PrivateAssets>all</PrivateAssets>

--- a/Apple.Receipt.Example/Apple.Receipt.Example.csproj
+++ b/Apple.Receipt.Example/Apple.Receipt.Example.csproj
@@ -1,13 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10</LangVersion>
+    <TargetFramework>net7.0</TargetFramework>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Apple.Receipt.Verificator" Version="2.2.4" />
+    <ProjectReference Include="..\Apple.Receipt.Verificator\Apple.Receipt.Verificator.csproj" />
   </ItemGroup>
-
 
 </Project>

--- a/Apple.Receipt.Models/Apple.Receipt.Models.csproj
+++ b/Apple.Receipt.Models/Apple.Receipt.Models.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <LangVersion>10</LangVersion>
     <Nullable>annotations</Nullable>
     <Authors>Sergey Shoshin</Authors>
     <PackageVersion>2.3.0</PackageVersion>
@@ -13,14 +12,15 @@
     <PackageLicense>MIT</PackageLicense>
     <PackageIcon>images/icon.png</PackageIcon>
     <PackageTags>Apple Receipt Models</PackageTags>
-    <PackageReleaseNotes>Migrated to .net 6.0</PackageReleaseNotes>
-    <TargetFramework>net6.0</TargetFramework>
+    <PackageReleaseNotes>Migrated to .NET 7.0 and NuGet package updates</PackageReleaseNotes>
+    <TargetFramework>net7.0</TargetFramework>
     <RepositoryUrl>https://github.com/shoshins/apple-receipt</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
   </PropertyGroup>
   <PropertyGroup>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -43,7 +43,11 @@
     <None Include="../icon.png" Pack="true" PackagePath="images/" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/Apple.Receipt.Models/Apple.Receipt.Models.nuspec
+++ b/Apple.Receipt.Models/Apple.Receipt.Models.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Apple.Receipt.Models</id>
-    <version>2.2.0</version>
+    <version>2.4.0</version>
     <title>Apple.Receipt.Models</title>
     <authors>Sergey Shoshin</authors>
     <owners>Sergey Shoshin</owners>

--- a/Apple.Receipt.Parser.Tests/Apple.Receipt.Parser.Tests.csproj
+++ b/Apple.Receipt.Parser.Tests/Apple.Receipt.Parser.Tests.csproj
@@ -1,17 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10</LangVersion>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>annotations</Nullable>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CompareNETObjects" Version="4.78.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="CompareNETObjects" Version="4.79.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/Apple.Receipt.Parser/Apple.Receipt.Parser.csproj
+++ b/Apple.Receipt.Parser/Apple.Receipt.Parser.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <LangVersion>10</LangVersion>
     <Nullable>annotations</Nullable>
     <Authors>Sergey Shoshin</Authors>
     <PackageVersion>2.3.0</PackageVersion>
@@ -13,12 +12,13 @@
     <PackageLicense>MIT</PackageLicense>
     <PackageIcon>images/icon.png</PackageIcon>
     <PackageTags>Apple Receipt Parser Base64 Asn1 Asn.1</PackageTags>
-    <PackageReleaseNotes>Migrated to .net 6.0</PackageReleaseNotes>
-    <TargetFramework>net6.0</TargetFramework>
+    <PackageReleaseNotes>Migrated to .NET 7.0</PackageReleaseNotes>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -41,8 +41,12 @@
     <None Include="../icon.png" Pack="true" PackagePath="images/" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Apple.Receipt.Models\Apple.Receipt.Models.csproj" />

--- a/Apple.Receipt.Parser/Apple.Receipt.Parser.nuspec
+++ b/Apple.Receipt.Parser/Apple.Receipt.Parser.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Apple.Receipt.Parser</id>
-    <version>2.2.0</version>
+    <version>2.4.0</version>
     <title>Apple.Receipt.Parser</title>
     <authors>Sergey Shoshin</authors>
     <owners>Sergey Shoshin</owners>

--- a/Apple.Receipt.Verificator.Tests/Apple.Receipt.Verificator.Tests.csproj
+++ b/Apple.Receipt.Verificator.Tests/Apple.Receipt.Verificator.Tests.csproj
@@ -1,15 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10</LangVersion>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>annotations</Nullable>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/Apple.Receipt.Verificator/Apple.Receipt.Verificator.csproj
+++ b/Apple.Receipt.Verificator/Apple.Receipt.Verificator.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <LangVersion>10</LangVersion>
     <Nullable>annotations</Nullable>
     <Authors>Sergey Shoshin</Authors>
     <PackageVersion>2.3.0</PackageVersion>
@@ -13,12 +12,13 @@
     <PackageLicense>MIT</PackageLicense>
     <PackageIcon>images/icon.png</PackageIcon>
     <PackageTags>Apple Receipt Validation AppStore</PackageTags>
-    <PackageReleaseNotes>Refit 6+ update. MSBuild version 16.8+ is now required. Migrated to .net 6.0</PackageReleaseNotes>
-    <TargetFramework>net6.0</TargetFramework>
+    <PackageReleaseNotes>Migrated to .NET 7.0 and NuGet package updates.</PackageReleaseNotes>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -41,13 +41,16 @@
     <None Include="../icon.png" Pack="true" PackagePath="images/" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Refit" Version="6.3.2" />
-    <PackageReference Include="Refit.HttpClientFactory" Version="6.3.2" />
-    <PackageReference Include="Refit.Newtonsoft.Json" Version="6.3.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Refit.HttpClientFactory" Version="6.5.1" />
+    <PackageReference Include="Refit.Newtonsoft.Json" Version="6.5.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Apple.Receipt.Parser\Apple.Receipt.Parser.csproj" />

--- a/Apple.Receipt.Verificator/Apple.Receipt.Verificator.nuspec
+++ b/Apple.Receipt.Verificator/Apple.Receipt.Verificator.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Apple.Receipt.Verificator</id>
-    <version>2.2.0</version>
+    <version>2.4.0</version>
     <title>Apple.Receipt.Verificator</title>
     <authors>Sergey Shoshin</authors>
     <owners>Sergey Shoshin</owners>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+    "sdk": {
+      "version": "7.0.100",
+      "rollForward": "latestFeature"
+    }
+}


### PR DESCRIPTION
This PR has a number of fixes which should improve quality of life.

### Incomplete: NuGet package Sourcelink

Currently the packages are missing some info which helps make debugging into the packages (in my own solution), do able.

Current:

![image](https://user-images.githubusercontent.com/899878/232488265-c2d4e70e-c914-4b3a-91a8-f063f833bf4d.png)

New:
![image](https://user-images.githubusercontent.com/899878/232488364-3f4115da-b5e0-4d89-a2ca-148fafd80c77.png)

This includes added `SourceLink` to the projects so we can link directly to GitHub. Lastly, I added the `-p:ContinuousIntegrationBuild=true` to enable determinism.

### NET60 -> NET70
- Added a `global.json` file which says: Use _the most recent version of_ .NET7.0  (major 7, minor 0). So if a .NET71 is released, this won't upgrade to that.
- Updated all the projects to be NET70
- Updated related "project" nugets to their v7 versions.

### Updated some other NuGets
- Updated Refit and Newtonsoft nugets.
- Resolves #23 
- Resolves #24
- Resolves #25 

### Updated GitHub actions
- While I was in these files, updated some various versions of some of the actions.

### Removed nuget dependencies from the Examples
- 2 of the example projects had references to the Apple.* nugets you made. Instead, they should be referencing the _projects_ so they (the example projects) are working off the _most recent version_. Otherwise, it's a mess doing updates over multiple PR's.